### PR TITLE
Harden against malicious JSONL injection

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -328,6 +328,8 @@ fn read_jsonl_summary(path: &std::path::Path) -> JsonlSummary {
         let _ = read_line_capped(&mut reader, &mut discard);
     }
 
+    // Heuristic: scan the last N lines for model/branch/tokens.
+    // In practice the last assistant entry is near the end of the file.
     const TAIL_LINES: usize = 50;
     let mut ring = std::collections::VecDeque::with_capacity(TAIL_LINES);
     let mut line = String::new();

--- a/src/history.rs
+++ b/src/history.rs
@@ -304,18 +304,51 @@ struct JsonlSummary {
 }
 
 /// Read model, branch, and total tokens from the last assistant entry in a JSONL file.
+/// Seeks to the tail of large files to avoid reading the entire file into memory.
 fn read_jsonl_summary(path: &std::path::Path) -> JsonlSummary {
-    let content = match fs::read_to_string(path) {
-        Ok(c) => c,
-        Err(_) => return JsonlSummary { model: None, branch: None, tokens: 0 },
+    use std::io::{BufReader, Seek, SeekFrom};
+    use crate::session::read_line_capped;
+
+    let empty = JsonlSummary { model: None, branch: None, tokens: 0 };
+    let file = match fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return empty,
     };
+    let size = file.metadata().map(|m| m.len()).unwrap_or(0);
+    let mut reader = BufReader::new(file);
+
+    // Only read the last 1MB — we only need the last ~50 lines.
+    const TAIL_BYTES: u64 = 1024 * 1024;
+    if size > TAIL_BYTES {
+        if reader.seek(SeekFrom::Start(size - TAIL_BYTES)).is_err() {
+            return empty;
+        }
+        // Discard partial first line after seek
+        let mut discard = String::new();
+        let _ = read_line_capped(&mut reader, &mut discard);
+    }
+
+    let mut lines = Vec::new();
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match read_line_capped(&mut reader, &mut line) {
+            Ok(0) => break,
+            Ok(_) => {
+                if !line.trim().is_empty() {
+                    lines.push(std::mem::take(&mut line));
+                }
+            }
+            Err(_) => break,
+        }
+    }
 
     let mut model = None;
     let mut branch = None;
     let mut input_tokens = 0u64;
     let mut output_tokens = 0u64;
 
-    for line in content.lines().rev().take(50) {
+    for line in lines.iter().rev().take(50) {
         // Pick up gitBranch from any recent entry
         if branch.is_none() && line.contains("\"gitBranch\"") {
             if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
@@ -332,8 +365,8 @@ fn read_jsonl_summary(path: &std::path::Path) -> JsonlSummary {
                     if input_tokens == 0 {
                         if let Some(usage) = msg.get("usage") {
                             input_tokens = usage.get("input_tokens").and_then(|t| t.as_u64()).unwrap_or(0)
-                                + usage.get("cache_creation_input_tokens").and_then(|t| t.as_u64()).unwrap_or(0)
-                                + usage.get("cache_read_input_tokens").and_then(|t| t.as_u64()).unwrap_or(0);
+                                .saturating_add(usage.get("cache_creation_input_tokens").and_then(|t| t.as_u64()).unwrap_or(0))
+                                .saturating_add(usage.get("cache_read_input_tokens").and_then(|t| t.as_u64()).unwrap_or(0));
                             output_tokens = usage.get("output_tokens").and_then(|t| t.as_u64()).unwrap_or(0);
                         }
                     }
@@ -348,7 +381,7 @@ fn read_jsonl_summary(path: &std::path::Path) -> JsonlSummary {
     JsonlSummary {
         model,
         branch,
-        tokens: input_tokens + output_tokens,
+        tokens: input_tokens.saturating_add(output_tokens),
     }
 }
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -328,7 +328,8 @@ fn read_jsonl_summary(path: &std::path::Path) -> JsonlSummary {
         let _ = read_line_capped(&mut reader, &mut discard);
     }
 
-    let mut lines = Vec::new();
+    const TAIL_LINES: usize = 50;
+    let mut ring = std::collections::VecDeque::with_capacity(TAIL_LINES);
     let mut line = String::new();
     loop {
         line.clear();
@@ -336,7 +337,10 @@ fn read_jsonl_summary(path: &std::path::Path) -> JsonlSummary {
             Ok(0) => break,
             Ok(_) => {
                 if !line.trim().is_empty() {
-                    lines.push(std::mem::take(&mut line));
+                    if ring.len() == TAIL_LINES {
+                        ring.pop_front();
+                    }
+                    ring.push_back(std::mem::take(&mut line));
                 }
             }
             Err(_) => break,
@@ -348,7 +352,7 @@ fn read_jsonl_summary(path: &std::path::Path) -> JsonlSummary {
     let mut input_tokens = 0u64;
     let mut output_tokens = 0u64;
 
-    for line in lines.iter().rev().take(50) {
+    for line in ring.iter().rev() {
         // Pick up gitBranch from any recent entry
         if branch.is_none() && line.contains("\"gitBranch\"") {
             if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {

--- a/src/session.rs
+++ b/src/session.rs
@@ -1220,3 +1220,101 @@ fn find_claude_child_pid(parent_pid: i32) -> Option<i32> {
         .find(|pid| sessions_dir.join(format!("{pid}.json")).exists())
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufReader, Cursor};
+
+    #[test]
+    fn read_line_capped_normal() {
+        let data = b"hello\nworld\n";
+        let mut reader = BufReader::new(Cursor::new(data));
+        let mut buf = String::new();
+
+        let n = read_line_capped(&mut reader, &mut buf).unwrap();
+        assert!(n > 0);
+        assert_eq!(buf, "hello\n");
+
+        buf.clear();
+        let n = read_line_capped(&mut reader, &mut buf).unwrap();
+        assert!(n > 0);
+        assert_eq!(buf, "world\n");
+
+        buf.clear();
+        let n = read_line_capped(&mut reader, &mut buf).unwrap();
+        assert_eq!(n, 0); // EOF
+    }
+
+    #[test]
+    fn read_line_capped_no_trailing_newline() {
+        let data = b"no newline";
+        let mut reader = BufReader::new(Cursor::new(data));
+        let mut buf = String::new();
+
+        let n = read_line_capped(&mut reader, &mut buf).unwrap();
+        assert!(n > 0);
+        assert_eq!(buf, "no newline");
+    }
+
+    #[test]
+    fn read_line_capped_empty() {
+        let data = b"";
+        let mut reader = BufReader::new(Cursor::new(data));
+        let mut buf = String::new();
+
+        let n = read_line_capped(&mut reader, &mut buf).unwrap();
+        assert_eq!(n, 0);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn read_line_capped_overlong_discarded() {
+        // Create a line that exceeds MAX_LINE_BYTES, followed by a normal line
+        let mut data = vec![b'x'; MAX_LINE_BYTES + 100];
+        data.push(b'\n');
+        data.extend_from_slice(b"ok\n");
+
+        let mut reader = BufReader::new(Cursor::new(data));
+        let mut buf = String::new();
+
+        // First line is overlong — should be discarded
+        let n = read_line_capped(&mut reader, &mut buf).unwrap();
+        assert!(n > 0); // consumed bytes, not EOF
+        assert!(buf.is_empty()); // but buf is empty
+
+        // Second line should read normally
+        buf.clear();
+        let n = read_line_capped(&mut reader, &mut buf).unwrap();
+        assert!(n > 0);
+        assert_eq!(buf, "ok\n");
+    }
+
+    #[test]
+    fn read_line_capped_overflow_clears_stale_buf() {
+        let mut data = vec![b'x'; MAX_LINE_BYTES + 100];
+        data.push(b'\n');
+
+        let mut reader = BufReader::new(Cursor::new(data));
+        let mut buf = String::from("stale data");
+
+        let n = read_line_capped(&mut reader, &mut buf).unwrap();
+        assert!(n > 0);
+        assert!(buf.is_empty()); // stale data cleared
+    }
+
+    #[test]
+    fn validate_cwd_rejects_relative() {
+        assert!(!validate_cwd("relative/path"));
+    }
+
+    #[test]
+    fn validate_cwd_rejects_nonexistent() {
+        assert!(!validate_cwd("/nonexistent/path/that/does/not/exist"));
+    }
+
+    #[test]
+    fn validate_cwd_accepts_real_dir() {
+        assert!(validate_cwd("/tmp"));
+    }
+}
+

--- a/src/session.rs
+++ b/src/session.rs
@@ -39,7 +39,7 @@ pub(crate) fn read_line_capped<R: Read>(
             } else {
                 overflowed = true;
                 raw = Vec::new();
-                buf.clear();
+                buf.clear(); // ensure buf is empty on overflow even if caller didn't pre-clear
             }
         }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -39,6 +39,7 @@ pub(crate) fn read_line_capped<R: Read>(
             } else {
                 overflowed = true;
                 raw = Vec::new();
+                buf.clear();
             }
         }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,12 +1,72 @@
 use std::collections::HashMap;
 use std::fs;
-use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use serde::Deserialize;
 
 use crate::model;
+
+/// Maximum bytes per JSONL line before discarding.
+/// Prevents OOM from malicious files with unbounded lines.
+const MAX_LINE_BYTES: usize = 10 * 1024 * 1024; // 10 MB
+
+/// Read a line with a cap on allocation. Uses fill_buf/consume to avoid
+/// allocating beyond the cap. Returns Ok(0) at EOF. Overlong lines are
+/// consumed and discarded (buf left empty, positive byte count returned
+/// so callers can distinguish from EOF).
+pub(crate) fn read_line_capped<R: Read>(
+    reader: &mut BufReader<R>,
+    buf: &mut String,
+) -> std::io::Result<usize> {
+    let mut raw = Vec::new();
+    let mut overflowed = false;
+    let mut total_consumed = 0usize;
+
+    loop {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            break;
+        }
+
+        let newline_pos = available.iter().position(|&b| b == b'\n');
+        let chunk_end = newline_pos.map(|p| p + 1).unwrap_or(available.len());
+
+        if !overflowed {
+            if raw.len() + chunk_end <= MAX_LINE_BYTES {
+                raw.extend_from_slice(&available[..chunk_end]);
+            } else {
+                overflowed = true;
+                raw = Vec::new();
+            }
+        }
+
+        total_consumed += chunk_end;
+        reader.consume(chunk_end);
+
+        if newline_pos.is_some() {
+            break;
+        }
+    }
+
+    if total_consumed == 0 {
+        return Ok(0); // EOF
+    }
+
+    if !overflowed {
+        *buf = String::from_utf8(raw).unwrap_or_default();
+    }
+
+    Ok(total_consumed)
+}
+
+/// Validate that a CWD path is safe to pass to external commands.
+/// Must be absolute and resolve to an existing directory.
+pub(crate) fn validate_cwd(cwd: &str) -> bool {
+    let path = Path::new(cwd);
+    path.is_absolute() && path.is_dir()
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum SessionStatus {
@@ -448,6 +508,14 @@ const GIT_CACHE_TTL: Duration = Duration::from_secs(30);
 
 /// Get the git project name, relative_dir, and branch for a directory (cached for 30s).
 fn git_project_info(cwd: &str) -> (String, Option<String>, Option<String>) {
+    if !validate_cwd(cwd) {
+        let fallback = Path::new(cwd)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| cwd.to_string());
+        return (fallback, None, None);
+    }
+
     {
         let cache = GIT_CACHE.lock().unwrap();
         if let Some(info) = cache.as_ref().and_then(|c| c.get(cwd)) {
@@ -670,7 +738,7 @@ fn parse_jsonl(
     let mut line = String::new();
     loop {
         line.clear();
-        match reader.read_line(&mut line) {
+        match read_line_capped(&mut reader, &mut line) {
             Ok(0) => break,
             Ok(_) => {}
             Err(_) => break,
@@ -912,8 +980,14 @@ pub fn find_session_cwd(session_id: &str) -> Option<String> {
             continue;
         }
         let file = fs::File::open(&jsonl_path).ok()?;
-        let reader = std::io::BufReader::new(file);
-        for line in reader.lines().take(20).flatten() {
+        let mut reader = BufReader::new(file);
+        let mut line = String::new();
+        for _ in 0..20 {
+            line.clear();
+            match read_line_capped(&mut reader, &mut line) {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {}
+            }
             if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) {
                 if let Some(cwd) = v.get("cwd").and_then(|c| c.as_str()) {
                     return Some(cwd.to_string());

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -20,6 +20,10 @@ pub fn switch_to_pane(target: &str) {
 /// Launch claude in a new tmux session with the given name and working directory.
 /// Returns the session name on success.
 pub fn create_session(name: &str, cwd: &str) -> Result<String, String> {
+    if !session::validate_cwd(cwd) {
+        return Err(format!("Invalid working directory: {cwd}"));
+    }
+
     let base_name = sanitize_session_name(name);
     let session_name = unique_session_name(&base_name);
 
@@ -145,17 +149,12 @@ pub fn kill_session(name: &str) -> bool {
 }
 
 /// Sanitize a string for use as a tmux session name.
-/// Replaces tmux-special characters and strips control chars / leading dashes
-/// to prevent injection via crafted directory names.
+/// Uses an allowlist (alphanumeric, `-`, `_`) to prevent injection via
+/// crafted directory names. Leading dashes are stripped to avoid flag injection.
 fn sanitize_session_name(name: &str) -> String {
     let sanitized: String = name
         .chars()
-        .filter(|c| !c.is_control())
-        .map(|c| match c {
-            '.' | ':' | '$' | '!' | '%' | '@' | '#' | '?' | '{' | '}' | '~' | '=' | ' '
-            | '\'' | '"' | '\\' | '/' => '-',
-            _ => c,
-        })
+        .map(|c| if c.is_alphanumeric() || c == '_' { c } else { '-' })
         .collect();
 
     let trimmed = sanitized.trim_start_matches('-');

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -56,7 +56,9 @@ pub fn resume_session(session_id: &str, name: Option<&str>) -> Result<String, St
         .unwrap_or_else(|| session_id[..6.min(session_id.len())].to_string());
 
     // Use the original session's cwd so we start in the right project directory.
+    // Validate before use — fall back to current dir if the JSONL cwd is invalid.
     let cwd = session::find_session_cwd(session_id)
+        .filter(|c| session::validate_cwd(c))
         .or_else(|| std::env::current_dir().map(|p| p.to_string_lossy().to_string()).ok())
         .unwrap_or_else(|| ".".to_string());
 
@@ -142,7 +144,25 @@ pub fn kill_session(name: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Sanitize a string for use as a tmux session name (no dots or colons).
+/// Sanitize a string for use as a tmux session name.
+/// Replaces tmux-special characters and strips control chars / leading dashes
+/// to prevent injection via crafted directory names.
 fn sanitize_session_name(name: &str) -> String {
-    name.replace('.', "-").replace(':', "-")
+    let sanitized: String = name
+        .chars()
+        .filter(|c| !c.is_control())
+        .map(|c| match c {
+            '.' | ':' | '$' | '!' | '%' | '@' | '#' | '?' | '{' | '}' | '~' | '=' | ' '
+            | '\'' | '"' | '\\' | '/' => '-',
+            _ => c,
+        })
+        .collect();
+
+    let trimmed = sanitized.trim_start_matches('-');
+
+    if trimmed.is_empty() {
+        "claude".to_string()
+    } else {
+        trimmed.to_string()
+    }
 }

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -165,3 +165,46 @@ fn sanitize_session_name(name: &str) -> String {
         trimmed.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_normal_name() {
+        assert_eq!(sanitize_session_name("my-project"), "my-project");
+        assert_eq!(sanitize_session_name("foo_bar"), "foo_bar");
+    }
+
+    #[test]
+    fn sanitize_dots_and_colons() {
+        assert_eq!(sanitize_session_name("my.project:1"), "my-project-1");
+    }
+
+    #[test]
+    fn sanitize_shell_metacharacters() {
+        assert_eq!(sanitize_session_name("$HOME;rm -rf /"), "HOME-rm--rf--");
+    }
+
+    #[test]
+    fn sanitize_control_chars() {
+        assert_eq!(sanitize_session_name("hello\x00\x1bworld"), "hello--world");
+    }
+
+    #[test]
+    fn sanitize_leading_dashes_stripped() {
+        assert_eq!(sanitize_session_name("--flag"), "flag");
+        assert_eq!(sanitize_session_name("...name"), "name");
+    }
+
+    #[test]
+    fn sanitize_all_special_becomes_claude() {
+        assert_eq!(sanitize_session_name("..."), "claude");
+        assert_eq!(sanitize_session_name(""), "claude");
+    }
+
+    #[test]
+    fn sanitize_unicode_preserved() {
+        assert_eq!(sanitize_session_name("café"), "café");
+    }
+}


### PR DESCRIPTION
## Summary
Closes #8

- Bounded JSONL line reader (`read_line_capped`) using `fill_buf`/`consume` to prevent OOM from crafted files with unbounded lines — applied to all four read sites
- CWD validation before passing to `git -C` and `tmux new-session -c`
- Expanded tmux session name sanitizer (control chars, shell-special chars, leading dashes)
- `read_jsonl_summary` now seeks to file tail instead of reading entire file into memory
- `saturating_add` for token arithmetic

cc @simonkeng @bluzername — would appreciate your review if interested.

## Test plan
- [x] `cargo build` compiles clean
- [x] All 13 e2e tests pass