### PR TITLE
Add tmux window name column to session table

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -86,6 +86,11 @@ impl App {
                         .unwrap_or("")
                         .to_lowercase()
                         .contains(&query)
+                    || s.tmux_window
+                        .as_deref()
+                        .unwrap_or("")
+                        .to_lowercase()
+                        .contains(&query)
             })
             .map(|(i, _)| i)
             .collect()
@@ -429,6 +434,7 @@ impl App {
                     "room_id": s.room_id(),
                     "relative_dir": s.relative_dir,
                     "tmux_session": s.tmux_session,
+                    "tmux_window": s.tmux_window,
                     "pane_target": s.pane_target,
                     "model": s.model,
                     "model_display": s.model_display(),

--- a/src/session.rs
+++ b/src/session.rs
@@ -96,6 +96,7 @@ pub struct Session {
     pub cwd: String,
     pub relative_dir: Option<String>,
     pub tmux_session: Option<String>,
+    pub tmux_window: Option<String>,
     pub pane_target: Option<String>,
     pub model: Option<String>,
     pub total_input_tokens: u64,
@@ -287,6 +288,7 @@ pub fn discover_sessions(prev_sessions: &HashMap<String, Session>) -> Vec<Sessio
                 cwd,
                 relative_dir,
                 tmux_session: Some(live.tmux_session.clone()),
+                tmux_window: Some(live.tmux_window.clone()),
                 pane_target: Some(live.pane_target.clone()),
                 model: info.model,
                 effort: info.effort,
@@ -382,6 +384,7 @@ pub fn discover_sessions(prev_sessions: &HashMap<String, Session>) -> Vec<Sessio
                 branch,
                 cwd,
                 tmux_session: Some(live.tmux_session.clone()),
+                tmux_window: Some(live.tmux_window.clone()),
                 pane_target: Some(live.pane_target.clone()),
                 model: info.model,
                 effort: info.effort,
@@ -406,6 +409,7 @@ pub fn discover_sessions(prev_sessions: &HashMap<String, Session>) -> Vec<Sessio
                 branch,
                 cwd: live.pane_cwd.clone(),
                 tmux_session: Some(live.tmux_session.clone()),
+                tmux_window: Some(live.tmux_window.clone()),
                 pane_target: Some(live.pane_target.clone()),
                 model: None,
                 effort: None,
@@ -443,6 +447,7 @@ fn truncate_to_minute(ts: &Option<String>) -> Option<String> {
 struct LiveSessionInfo {
     pid: i32,
     tmux_session: String,
+    tmux_window: String,
     pane_target: String,
     pane_cwd: String,
     started_at: u64,
@@ -458,13 +463,14 @@ fn build_live_session_map() -> HashMap<String, LiveSessionInfo> {
     let tmux_panes = discover_claude_tmux_panes();
 
     let mut map = HashMap::new();
-    for (pid, tmux_session, pane_target, pane_cwd) in tmux_panes {
+    for (pid, tmux_session, tmux_window, pane_target, pane_cwd) in tmux_panes {
         if let Some(info) = pid_session_map.get(&pid) {
             map.insert(
                 info.session_id.clone(),
                 LiveSessionInfo {
                     pid,
                     tmux_session,
+                    tmux_window,
                     pane_target,
                     pane_cwd,
                     started_at: info.started_at,
@@ -479,6 +485,7 @@ fn build_live_session_map() -> HashMap<String, LiveSessionInfo> {
                 LiveSessionInfo {
                     pid,
                     tmux_session,
+                    tmux_window,
                     pane_target,
                     pane_cwd,
                     started_at: 0,
@@ -1156,13 +1163,13 @@ fn read_pid_session_map() -> HashMap<i32, SessionFileInfo> {
 
 /// Get tmux panes running claude.
 /// Returns Vec<(pid, session_name, pane_cwd)>.
-fn discover_claude_tmux_panes() -> Vec<(i32, String, String, String)> {
+fn discover_claude_tmux_panes() -> Vec<(i32, String, String, String, String)> {
     let output = match std::process::Command::new("tmux")
         .args([
             "list-panes",
             "-a",
             "-F",
-            "#{pane_pid}|||#{session_name}|||#{pane_current_command}|||#{pane_current_path}|||#{window_index}|||#{pane_index}",
+            "#{pane_pid}|||#{session_name}|||#{pane_current_command}|||#{pane_current_path}|||#{window_index}|||#{pane_index}|||#{window_name}",
         ])
         .output()
     {
@@ -1177,8 +1184,8 @@ fn discover_claude_tmux_panes() -> Vec<(i32, String, String, String)> {
         .unwrap_or_default();
 
     for line in stdout.lines() {
-        let parts: Vec<&str> = line.splitn(6, "|||").collect();
-        if parts.len() < 6 {
+        let parts: Vec<&str> = line.splitn(7, "|||").collect();
+        if parts.len() < 7 {
             continue;
         }
         let pid: i32 = match parts[0].parse() {
@@ -1190,6 +1197,7 @@ fn discover_claude_tmux_panes() -> Vec<(i32, String, String, String)> {
         let pane_path = parts[3];
         let window_index = parts[4];
         let pane_index = parts[5];
+        let window_name = parts[6];
 
         // Claude shows up as a version number (e.g. "2.1.76") or "claude" or "node"
         let is_claude = command
@@ -1211,12 +1219,24 @@ fn discover_claude_tmux_panes() -> Vec<(i32, String, String, String)> {
             };
             if let Some(cpid) = claude_pid {
                 let pane_target = format!("{session_name}:{window_index}.{pane_index}");
-                results.push((cpid, session_name.to_string(), pane_target, pane_path.to_string()));
+                results.push((
+                    cpid,
+                    session_name.to_string(),
+                    window_name.to_string(),
+                    pane_target,
+                    pane_path.to_string(),
+                ));
             }
         } else if command == "bash" || command == "sh" || command == "zsh" {
             if let Some(claude_pid) = find_claude_child_pid(pid) {
                 let pane_target = format!("{session_name}:{window_index}.{pane_index}");
-                results.push((claude_pid, session_name.to_string(), pane_target, pane_path.to_string()));
+                results.push((
+                    claude_pid,
+                    session_name.to_string(),
+                    window_name.to_string(),
+                    pane_target,
+                    pane_path.to_string(),
+                ));
             }
         }
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -39,6 +39,7 @@ fn render_table(frame: &mut Frame, app: &App, area: Rect) {
     let header = Row::new(vec![
         Cell::from(" # "),
         Cell::from("Session"),
+        Cell::from("Window"),
         Cell::from("Project"),
         Cell::from("Directory"),
         Cell::from("Status"),
@@ -63,6 +64,12 @@ fn render_table(frame: &mut Frame, app: &App, area: Rect) {
             let tmux_name = session
                 .tmux_session
                 .as_deref()
+                .unwrap_or("—");
+
+            let window_name = session
+                .tmux_window
+                .as_deref()
+                .filter(|w| !w.is_empty())
                 .unwrap_or("—");
 
             // Status: colored dot + label
@@ -120,6 +127,7 @@ fn render_table(frame: &mut Frame, app: &App, area: Rect) {
             let row = Row::new(vec![
                 Cell::from(num),
                 Cell::from(tmux_name.to_string()),
+                Cell::from(window_name.to_string()).style(Style::default().fg(Color::Magenta)),
                 project_cell,
                 dir_cell,
                 status_cell,
@@ -141,6 +149,7 @@ fn render_table(frame: &mut Frame, app: &App, area: Rect) {
     let widths = [
         Constraint::Length(4),   // #
         Constraint::Length(16),  // Session
+        Constraint::Length(16),  // Window
         Constraint::Min(20),    // Project (repo + branch)
         Constraint::Length(20), // Directory
         Constraint::Length(10), // Status

--- a/src/view_ui.rs
+++ b/src/view_ui.rs
@@ -681,6 +681,7 @@ mod tests {
             cwd: cwd.to_string(),
             relative_dir: None,
             tmux_session: None,
+            tmux_window: None,
             pane_target: None,
             model: None,
             effort: None,


### PR DESCRIPTION
Implements part 2 of #20.

## Problem
When multiple Claude agents run inside a single tmux session (one session, many windows), the `Session` column is identical across rows and no longer differentiates them.

## Change
Capture `#{window_name}` from `tmux list-panes` and surface it as a new **Window** column, placed between `Session` and `Project`.

- New `tmux_window` field on `Session`, threaded through `LiveSessionInfo` and all three session-construction paths in `discover_sessions`.
- Rendered in the table (magenta), falling back to `—` when empty.
- Included in JSON output (`--json`) and matched by the `/` search filter.

## Testing
- `cargo build` clean
- `cargo test` — 23 passed

Pre-existing `cargo fmt`/`clippy` warnings on `main` are left untouched to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)