### PR TITLE
Fix context-window sizes for 1M-context models (#21)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Process-to-session matching uses `~/.claude/sessions/{PID}.json` files written b
 - **app.rs** — state container, refresh loop, key handling, JSON serialization
 - **ui.rs** — ratatui rendering (table, status dots, color coding)
 - **tmux.rs** — session creation, switching, name sanitization
-- **model.rs** — model ID → display name/context window mapping
+- **model.rs** — model ID → display name/context window mapping. Constants are sourced from Anthropic's official models overview: https://platform.claude.com/docs/en/about-claude/models/overview.md (fetch the `.md` variant for an easy diff). When a new model ships or a context window is wrong, refresh from that page — see the module-level doc comment in `src/model.rs` for the last-synced table. Context-window size is per-model, not per-tier (e.g. Sonnet 4.6 is 1M but Sonnet 4.5 is 200k), so list each model explicitly.
 - **new_session.rs** — interactive two-field form for creating sessions
 
 ### Key caches

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,8 +1,43 @@
+//! Model ID → display name and context-window mappings.
+//!
+//! ## Source of truth
+//!
+//! The context-window sizes below come from Anthropic's official models
+//! overview. When a new model ships, refresh these constants from:
+//!
+//!   https://platform.claude.com/docs/en/about-claude/models/overview.md
+//!
+//! (the `.md` variant is plain markdown and easy to diff). The page lists every
+//! current and legacy model with its exact API ID and context window. Last
+//! synced 2026-07-17:
+//!
+//! | Model        | API ID                       | Context window |
+//! |--------------|------------------------------|----------------|
+//! | Fable 5      | claude-fable-5               | 1M             |
+//! | Opus 4.8     | claude-opus-4-8              | 1M             |
+//! | Opus 4.7     | claude-opus-4-7              | 1M             |
+//! | Opus 4.6     | claude-opus-4-6              | 1M             |
+//! | Opus 4.5     | claude-opus-4-5-20251101     | 200k           |
+//! | Sonnet 5     | claude-sonnet-5              | 1M             |
+//! | Sonnet 4.6   | claude-sonnet-4-6            | 1M             |
+//! | Sonnet 4.5   | claude-sonnet-4-5-20250929   | 200k           |
+//! | Haiku 4.5    | claude-haiku-4-5-20251001    | 200k           |
+//!
+//! Note: 1M-token context is not tied to a tier — Sonnet 4.6 and Sonnet 5 have
+//! it, but Sonnet 4.5 does not — so each model must be listed explicitly rather
+//! than inferred from the family name.
+
 /// Map raw model IDs to human-friendly display names.
 pub fn display_name(model_id: &str) -> &str {
     match model_id {
+        "claude-fable-5" => "Fable 5",
+        "claude-opus-4-8" => "Opus 4.8",
+        "claude-opus-4-7" => "Opus 4.7",
         "claude-opus-4-6" => "Opus 4.6",
+        "claude-opus-4-5-20251101" => "Opus 4.5",
+        "claude-sonnet-5" => "Sonnet 5",
         "claude-sonnet-4-6" => "Sonnet 4.6",
+        "claude-sonnet-4-5-20250929" => "Sonnet 4.5",
         "claude-sonnet-4-5-20250514" => "Sonnet 4.5",
         "claude-haiku-4-5-20251001" => "Haiku 4.5",
         "claude-opus-4-20250514" => "Opus 4",
@@ -14,23 +49,45 @@ pub fn display_name(model_id: &str) -> &str {
 /// Context window size for a given model ID.
 pub fn context_window(model_id: &str) -> u64 {
     match model_id {
+        "claude-fable-5" => 1_000_000,
+        "claude-opus-4-8" => 1_000_000,
+        "claude-opus-4-7" => 1_000_000,
         "claude-opus-4-6" => 1_000_000,
-        "claude-sonnet-4-6" => 200_000,
+        "claude-opus-4-5-20251101" => 200_000,
+        "claude-sonnet-5" => 1_000_000,
+        "claude-sonnet-4-6" => 1_000_000,
+        "claude-sonnet-4-5-20250929" => 200_000,
         "claude-sonnet-4-5-20250514" => 200_000,
         "claude-haiku-4-5-20251001" => 200_000,
         "claude-opus-4-20250514" => 200_000,
         "claude-sonnet-4-20250514" => 200_000,
+        // Unlisted Opus 4.6+ (e.g. future dated variants) default to 1M, not 200k.
+        _ if is_opus_1m(model_id) => 1_000_000,
         _ => 200_000,
     }
+}
+
+/// Whether an unlisted model ID is an Opus minor version 4.6 or newer (1M
+/// context). Legacy dated `claude-opus-4-*` has no minor version and returns false.
+fn is_opus_1m(model_id: &str) -> bool {
+    let Some(rest) = model_id.strip_prefix("claude-opus-4-") else {
+        return false;
+    };
+    let minor: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    matches!(minor.parse::<u32>(), Ok(n) if n >= 6)
 }
 
 /// Reverse lookup: display name (from /model output) → model ID.
 /// Returns None if the display name is not recognized.
 pub fn id_from_display_name(display: &str) -> Option<&'static str> {
     match display {
+        "Fable 5" | "Fable 5 (1M context)" => Some("claude-fable-5"),
+        "Opus 4.8" | "Opus 4.8 (1M context)" => Some("claude-opus-4-8"),
+        "Opus 4.7" | "Opus 4.7 (1M context)" => Some("claude-opus-4-7"),
         "Opus 4.6" | "Opus 4.6 (1M context)" => Some("claude-opus-4-6"),
+        "Sonnet 5" | "Sonnet 5 (1M context)" => Some("claude-sonnet-5"),
         "Sonnet 4.6" => Some("claude-sonnet-4-6"),
-        "Sonnet 4.5" => Some("claude-sonnet-4-5-20250514"),
+        "Sonnet 4.5" => Some("claude-sonnet-4-5-20250929"),
         "Haiku 4.5" => Some("claude-haiku-4-5-20251001"),
         "Opus 4" => Some("claude-opus-4-20250514"),
         "Sonnet 4" => Some("claude-sonnet-4-20250514"),
@@ -45,5 +102,35 @@ pub fn format_with_effort(model_id: &str, effort: &str) -> String {
         name.to_string()
     } else {
         format!("{name} ({effort})")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn one_million_context_models() {
+        assert_eq!(context_window("claude-fable-5"), 1_000_000);
+        assert_eq!(context_window("claude-opus-4-8"), 1_000_000);
+        assert_eq!(context_window("claude-opus-4-7"), 1_000_000);
+        assert_eq!(context_window("claude-opus-4-6"), 1_000_000);
+        assert_eq!(context_window("claude-sonnet-5"), 1_000_000);
+        assert_eq!(context_window("claude-sonnet-4-6"), 1_000_000);
+    }
+
+    #[test]
+    fn future_dated_opus_variants_fall_back_to_1m() {
+        assert_eq!(context_window("claude-opus-4-7-20260101"), 1_000_000);
+        assert_eq!(context_window("claude-opus-4-9"), 1_000_000);
+    }
+
+    #[test]
+    fn two_hundred_k_context_models() {
+        assert_eq!(context_window("claude-opus-4-5-20251101"), 200_000);
+        assert_eq!(context_window("claude-sonnet-4-5-20250929"), 200_000);
+        assert_eq!(context_window("claude-haiku-4-5-20251001"), 200_000);
+        assert_eq!(context_window("claude-opus-4-20250514"), 200_000);
+        assert_eq!(context_window("something-unknown"), 200_000);
     }
 }


### PR DESCRIPTION
Fixes #21.

## Problem
The Context column format is `<current> / <max>`, but `<max>` was hardcoded to 200k for any model not listed explicitly. Sessions on 1M-context models (Opus 4.7/4.8, Sonnet 4.6, Fable 5, …) showed a broken-looking ratio like `864k / 200k` when they were actually ~86% of a 1M window.

## Root cause
`context_window()` in `src/model.rs` matches exact model IDs and falls through to a `200_000` default. Newly released models (and `claude-sonnet-4-6`, which was wrongly set to 200k) were not covered.

## Fix
- Correct `claude-sonnet-4-6` → 1M.
- Add missing current models: `claude-fable-5`, `claude-sonnet-5`, `claude-opus-4-8`, `claude-opus-4-5` (plus display names / reverse lookup).
- Keep a prefix fallback so future dated Opus 4.6+ variants default to 1M.
- Values sourced from Anthropic's official [models overview](https://platform.claude.com/docs/en/about-claude/models/overview.md); documented in the `model.rs` module doc-comment and `CLAUDE.md` so constants can be refreshed mechanically. Context size is per-model, not per-tier (Sonnet 4.6 is 1M but Sonnet 4.5 is 200k), so each model is listed explicitly.

## Tests
Added unit tests covering the 1M models, the 200k models, and the Opus prefix fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)