### PR TITLE
Fix `new` status misattribution for resumed sessions (#22)

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -867,12 +867,55 @@ fn parse_jsonl(
 ///  2. Fall back to parsing `ps` args for sessions started outside of recon
 ///     (e.g. the user ran `claude --resume <id>` in a tmux session manually).
 fn find_jsonl_for_resumed_session(tmux_session: &str, pid: i32) -> Option<PathBuf> {
-    // Try tmux environment variable first (set by recon --resume)
-    let original_id = read_tmux_env(tmux_session, "RECON_RESUMED_FROM")
-        // Fall back to parsing ps args
-        .or_else(|| parse_resume_id_from_ps(pid))?;
+    // Try tmux environment variable first (set by recon --resume), then fall
+    // back to parsing `--resume <id>` from ps args.
+    read_tmux_env(tmux_session, "RECON_RESUMED_FROM")
+        .or_else(|| parse_resume_id_from_ps(pid))
+        .and_then(|id| find_jsonl_by_session_id(&id))
+        // Last resort: ask the OS which JSONL the process has open. This is the
+        // authoritative link and covers cases the two methods above miss —
+        // in-app /resume (no --resume in argv, no env var) and ps arg
+        // truncation — which otherwise misattribute the session as New (issue #22).
+        .or_else(|| find_jsonl_by_open_fd(pid))
+}
 
-    find_jsonl_by_session_id(&original_id)
+/// Find the JSONL a live claude process has open, by inspecting its file
+/// descriptors via lsof. A running claude keeps its session JSONL open for
+/// appending, so this is the most reliable process→JSONL link — independent
+/// of argv or resume bookkeeping.
+fn find_jsonl_by_open_fd(pid: i32) -> Option<PathBuf> {
+    let output = std::process::Command::new("lsof")
+        .args(["-p", &pid.to_string(), "-Fn"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let projects_marker = format!(
+        "{}{}",
+        std::path::MAIN_SEPARATOR,
+        Path::new(".claude").join("projects").display()
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut best: Option<(PathBuf, u64)> = None;
+    for line in stdout.lines() {
+        // lsof -Fn emits one field per line; name fields start with 'n'.
+        let name = match line.strip_prefix('n') {
+            Some(n) => n,
+            None => continue,
+        };
+        if !name.ends_with(".jsonl") || !name.contains(&projects_marker) {
+            continue;
+        }
+        let path = PathBuf::from(name);
+        let size = path.metadata().ok().map(|m| m.len()).unwrap_or(0);
+        if best.as_ref().map_or(true, |(_, s)| size > *s) {
+            best = Some((path, size));
+        }
+    }
+    best.map(|(p, _)| p)
 }
 
 /// Read a variable from a tmux session's environment table.

--- a/tests/e2e_discovery.sh
+++ b/tests/e2e_discovery.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Deterministic, claude-free discovery tests.
+#
+# Unlike e2e.sh (which drives real `claude` and asserts timing-dependent
+# states), these tests fabricate the four data sources recon joins
+# (tmux panes, ~/.claude/sessions/{PID}.json, ~/.claude/projects/*.jsonl,
+# pane content) using a `node`-backed stub pane and a scratch $HOME. That
+# makes them fast and deterministic — suitable for CI without claude.
+#
+# Requires: tmux, node, jq, lsof.
+set -euo pipefail
+
+RECON="$(cd "$(dirname "$0")/.." && pwd)/target/debug/recon"
+PASS=0
+FAIL=0
+
+RID=$(head -c 100 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 4)
+SANDBOX="/tmp/recon-disc-${RID}"
+HOME_DIR="$SANDBOX/home"
+SESSIONS_DIR="$HOME_DIR/.claude/sessions"
+PROJ_DIR="$HOME_DIR/.claude/projects/-tmp-disc-${RID}"
+PANE_CWD="/tmp/disc-${RID}-cwd"
+
+report() {
+    local result="$1" label="$2"
+    if [[ "$result" == "pass" ]]; then
+        echo "[PASS] $label"; (( PASS++ )) || true
+    else
+        echo "[FAIL] $label"; (( FAIL++ )) || true
+    fi
+}
+
+cleanup() {
+    tmux list-sessions -F '#{session_name}' 2>/dev/null \
+        | grep "^disc-${RID}-" \
+        | while read -r s; do tmux kill-session -t "$s" 2>/dev/null || true; done
+    rm -rf "$SANDBOX" "$PANE_CWD"
+}
+trap cleanup EXIT
+
+# --- Preflight ---
+for bin in tmux node jq lsof; do
+    if ! command -v "$bin" &>/dev/null; then
+        echo "SKIP: '$bin' is required but not found"
+        exit 0
+    fi
+done
+if [[ ! -x "$RECON" ]]; then
+    echo "FATAL: recon binary not found at $RECON (run 'cargo build' first)"
+    exit 1
+fi
+
+mkdir -p "$SESSIONS_DIR" "$PROJ_DIR" "$PANE_CWD"
+
+# recon_json <session_name> <field>: read one field for a tmux session.
+recon_json() {
+    HOME="$HOME_DIR" "$RECON" json 2>/dev/null \
+        | jq -r --arg n "$1" ".sessions[] | select(.tmux_session == \$n) | .$2"
+}
+
+# spawn_stub <session> <pid_file_sessionid> <jsonl_basename> <input_tokens>:
+# start a node-backed pane that keeps the JSONL open (as real claude does),
+# write its {pid}.json advertising <pid_file_sessionid>, and create a JSONL
+# named <jsonl_basename> carrying <input_tokens>. When the two session-ids
+# differ this mimics a resumed session (claude appends to the original JSONL
+# while sessions/{pid}.json advertises a fresh id).
+spawn_stub() {
+    local sess="$1" adv_sid="$2" jsonl_base="$3" tokens="$4"
+    local jsonl_path="$PROJ_DIR/${jsonl_base}.jsonl"
+    local now_ms=$(( $(date +%s) * 1000 ))
+    local iso; iso=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+
+    if (( tokens > 0 )); then
+        printf '%s\n' "{\"type\":\"assistant\",\"timestamp\":\"$iso\",\"cwd\":\"$PANE_CWD\",\"message\":{\"model\":\"claude-opus-4-8\",\"usage\":{\"input_tokens\":$tokens,\"output_tokens\":50,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}" > "$jsonl_path"
+    else
+        : > "$jsonl_path"
+    fi
+
+    # node keeps an fd open on the JSONL, exactly like a live claude process
+    JF="$jsonl_path" tmux new-session -d -s "$sess" -c "$PANE_CWD" \
+        "node -e 'require(\"fs\").openSync(process.env.JF,\"r\");setInterval(()=>{},1e9)'"
+    sleep 0.3
+
+    local ppid; ppid=$(tmux list-panes -t "$sess" -F '#{pane_pid}')
+    printf '{"pid":%s,"sessionId":"%s","startedAt":%s}\n' "$ppid" "$adv_sid" "$now_ms" \
+        > "$SESSIONS_DIR/${ppid}.json"
+}
+
+echo "Discovery test run ID: $RID (HOME=$HOME_DIR)"
+
+# --- Test: resumed session must not be misattributed as New (issue #22) ---
+# A resumed session advertises a fresh sessionId in sessions/{pid}.json while
+# claude keeps appending to the original JSONL. recon must relink the two and
+# show the real token count, not fall back to the "New" 0-token placeholder.
+if true; then
+    ADV_SID="99999999-dead-beef-cafe-999999999999"   # id in sessions/{pid}.json
+    ORIG_SID="11111111-2222-3333-4444-555555555555"  # id of the on-disk JSONL
+    spawn_stub "disc-${RID}-resumed" "$ADV_SID" "$ORIG_SID" 8000
+
+    STATUS=$(recon_json "disc-${RID}-resumed" "status")
+    TOKENS=$(recon_json "disc-${RID}-resumed" "total_input_tokens")
+
+    if [[ "$STATUS" != "New" ]] && [[ "$TOKENS" =~ ^[0-9]+$ ]] && (( TOKENS == 8000 )); then
+        report pass "Resumed session relinked: status=$STATUS tokens=$TOKENS"
+    else
+        echo "  Expected non-New status with 8000 tokens; got status='$STATUS' tokens='$TOKENS'"
+        HOME="$HOME_DIR" "$RECON" json 2>/dev/null \
+            | jq -r --arg n "disc-${RID}-resumed" '.sessions[] | select(.tmux_session == $n)' \
+            | sed 's/^/    /'
+        report fail "Resumed session misattributed as New (issue #22)"
+    fi
+fi
+
+# --- Test: a genuinely brand-new session (empty JSONL) still shows New ---
+# Guards against the fix over-correcting and hiding real New sessions.
+if true; then
+    NEW_SID="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    spawn_stub "disc-${RID}-fresh" "$NEW_SID" "$NEW_SID" 0
+
+    STATUS=$(recon_json "disc-${RID}-fresh" "status")
+    if [[ "$STATUS" == "New" ]]; then
+        report pass "Brand-new session still shows New: status=$STATUS"
+    else
+        report fail "Brand-new session should be New, got status='$STATUS'"
+    fi
+fi
+
+echo
+echo "Discovery results: $PASS passed, $FAIL failed"
+(( FAIL == 0 ))


### PR DESCRIPTION
Fixes #22.

## Problem

The `new` status indicator lands on a session with real history and then flickers off a poll cycle later, without user interaction.

Root cause: recon's `New` means "no JSONL data resolved (0 tokens)". A **resumed** session advertises a fresh `sessionId` in `~/.claude/sessions/{PID}.json` while claude keeps appending to the *original* JSONL (named after the old id). recon relinked the two only via:

1. the `RECON_RESUMED_FROM` tmux env var (set by `recon --resume`), or
2. parsing `--resume <id>` from `ps` args.

When neither is available — claude's in-app `/resume` (no `--resume` in argv, no env var), a `sessionId` change after compaction, or `ps` arg truncation/races under load (the reporter had 8+ sessions) — the session fell through to the `New` 0-token placeholder. The `prev_sessions` cache usually masks it after the first successful resolve, which is exactly why it was intermittent and self-clearing.

## Fix

Add `find_jsonl_by_open_fd()` as a last-resort relink. A live claude process keeps its session JSONL open, so `lsof` gives the authoritative process→JSONL link, independent of argv or resume bookkeeping. It's the final `.or_else` in the chain, so the `RECON_RESUMED_FROM` fast path is untouched and there's no regression risk to the existing resume flow.

## Reproduction & test

Real-`claude` e2e can't deterministically force the missing-relink condition (`claude --resume <id>` always puts `--resume` in argv), so a faithful repro there would be flaky. Instead this adds **`tests/e2e_discovery.sh`** — deterministic, claude-free discovery tests driven by a `node`-backed stub pane (recognized as claude) and a scratch `$HOME`:

- **red before / green after**: a resumed session (sessions/{pid}.json id ≠ JSONL name, JSONL held open) must report its real tokens, not `New`.
- **guard**: a genuinely brand-new session (empty JSONL) still shows `New`.

```
[PASS] Resumed session relinked: status=Idle tokens=8000
[PASS] Brand-new session still shows New: status=New
```

Requires `tmux`, `node`, `jq`, `lsof`; skips cleanly if any is missing, so it can run in CI without claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)