### PR TITLE
Reformat codebase and stabilize e2e tests

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -20,8 +20,8 @@ pub struct App {
     pub tick: u64,
     pub view_page: usize,
     pub view_zoomed_room: Option<String>, // room name when zoomed in
-    pub view_zoom_index: Option<usize>,  // pending zoom request from key press
-    pub view_selected_agent: usize,      // selected agent within zoomed room
+    pub view_zoom_index: Option<usize>,   // pending zoom request from key press
+    pub view_selected_agent: usize,       // selected agent within zoomed room
     pub filter_active: bool,              // search input has focus
     pub filter_text: String,              // current search query
     pub filter_cursor: usize,             // cursor position in query
@@ -130,7 +130,11 @@ impl App {
     }
 
     fn jump_to_next_input(&mut self) {
-        if let Some(session) = self.sessions.iter().find(|s| s.status == session::SessionStatus::Input) {
+        if let Some(session) = self
+            .sessions
+            .iter()
+            .find(|s| s.status == session::SessionStatus::Input)
+        {
             if let Some(target) = &session.pane_target {
                 tmux::switch_to_pane(target);
                 self.should_quit = true;
@@ -300,11 +304,15 @@ impl App {
             }
             KeyCode::Backspace => {
                 if self.filter_cursor > 0 {
-                    let byte_pos = self.filter_text.char_indices()
+                    let byte_pos = self
+                        .filter_text
+                        .char_indices()
                         .nth(self.filter_cursor - 1)
                         .map(|(i, _)| i)
                         .unwrap_or(0);
-                    let next_byte = self.filter_text.char_indices()
+                    let next_byte = self
+                        .filter_text
+                        .char_indices()
                         .nth(self.filter_cursor)
                         .map(|(i, _)| i)
                         .unwrap_or(self.filter_text.len());
@@ -316,11 +324,15 @@ impl App {
             KeyCode::Delete => {
                 let char_count = self.filter_text.chars().count();
                 if self.filter_cursor < char_count {
-                    let byte_pos = self.filter_text.char_indices()
+                    let byte_pos = self
+                        .filter_text
+                        .char_indices()
                         .nth(self.filter_cursor)
                         .map(|(i, _)| i)
                         .unwrap_or(self.filter_text.len());
-                    let next_byte = self.filter_text.char_indices()
+                    let next_byte = self
+                        .filter_text
+                        .char_indices()
                         .nth(self.filter_cursor + 1)
                         .map(|(i, _)| i)
                         .unwrap_or(self.filter_text.len());
@@ -367,7 +379,9 @@ impl App {
                 self.jump_to_next_input();
             }
             KeyCode::Char(c) => {
-                let byte_pos = self.filter_text.char_indices()
+                let byte_pos = self
+                    .filter_text
+                    .char_indices()
                     .nth(self.filter_cursor)
                     .map(|(i, _)| i)
                     .unwrap_or(self.filter_text.len());
@@ -423,9 +437,9 @@ impl App {
             .iter()
             .enumerate()
             .filter(|(_, s)| {
-                filters.iter().all(|(k, v)| {
-                    s.tags.get(*k).map_or(false, |tv| tv == v)
-                })
+                filters
+                    .iter()
+                    .all(|(k, v)| s.tags.get(*k).map_or(false, |tv| tv == v))
             })
             .map(|(i, s)| {
                 serde_json::json!({
@@ -460,5 +474,3 @@ impl App {
         .unwrap_or_else(|_| "{}".to_string())
     }
 }
-
-

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,8 +117,8 @@ pub fn load() -> Result<Config, String> {
         Err(e) => return Err(format!("Failed to read config {}: {e}", path.display())),
     };
 
-    let config: Config = toml::from_str(&content)
-        .map_err(|e| format!("Invalid config {}:\n{e}", path.display()))?;
+    let config: Config =
+        toml::from_str(&content).map_err(|e| format!("Invalid config {}:\n{e}", path.display()))?;
 
     if config.table.columns.is_empty() {
         return Err(format!(

--- a/src/history.rs
+++ b/src/history.rs
@@ -106,7 +106,9 @@ fn find_resumable_sessions() -> Vec<ResumeEntry> {
 }
 
 fn get_live_session_ids() -> HashSet<String> {
-    crate::session::build_live_session_map_public().into_keys().collect()
+    crate::session::build_live_session_map_public()
+        .into_keys()
+        .collect()
 }
 
 /// Interactive TUI picker for resuming a past session.
@@ -124,8 +126,8 @@ pub fn run_resume_picker() -> io::Result<Option<(String, String)>> {
 
     loop {
         terminal.draw(|f| {
-            let chunks = Layout::vertical([Constraint::Min(1), Constraint::Length(1)])
-                .split(f.area());
+            let chunks =
+                Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(f.area());
 
             let block = Block::default()
                 .borders(Borders::ALL)
@@ -147,16 +149,25 @@ pub fn run_resume_picker() -> io::Result<Option<(String, String)>> {
                     Cell::from("Context"),
                     Cell::from("Last Active"),
                 ])
-                .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD));
+                .style(
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                );
 
                 // Compute max git column width from actual data
-                let git_col_width = entries.iter().map(|e| {
-                    let project = dir_name(&e.cwd);
-                    match &e.branch {
-                        Some(b) => project.len() + 2 + b.len(), // "project::branch"
-                        None => project.len(),
-                    }
-                }).max().unwrap_or(10) as u16 + 2; // +2 for padding
+                let git_col_width = entries
+                    .iter()
+                    .map(|e| {
+                        let project = dir_name(&e.cwd);
+                        match &e.branch {
+                            Some(b) => project.len() + 2 + b.len(), // "project::branch"
+                            None => project.len(),
+                        }
+                    })
+                    .max()
+                    .unwrap_or(10) as u16
+                    + 2; // +2 for padding
 
                 let rows: Vec<Row> = entries
                     .iter()
@@ -180,10 +191,16 @@ pub fn run_resume_picker() -> io::Result<Option<(String, String)>> {
                             .map(|m| model::display_name(m).to_string())
                             .unwrap_or_else(|| "—".to_string());
 
-                        let window = e.model.as_deref()
+                        let window = e
+                            .model
+                            .as_deref()
                             .map(model::context_window)
                             .unwrap_or(200_000);
-                        let tokens = format!("{}k / {}", e.tokens / 1000, crate::session::format_window(window));
+                        let tokens = format!(
+                            "{}k / {}",
+                            e.tokens / 1000,
+                            crate::session::format_window(window)
+                        );
                         let exited = format_relative(&e.last_active);
 
                         let row = Row::new(vec![
@@ -204,11 +221,11 @@ pub fn run_resume_picker() -> io::Result<Option<(String, String)>> {
                     .collect();
 
                 let widths = [
-                    Constraint::Length(4),              // #
-                    Constraint::Length(12),             // Session ID
-                    Constraint::Length(git_col_width),  // Git(Project::Branch)
-                    Constraint::Length(14),             // Model
-                    Constraint::Length(14),             // Context
+                    Constraint::Length(4),             // #
+                    Constraint::Length(12),            // Session ID
+                    Constraint::Length(git_col_width), // Git(Project::Branch)
+                    Constraint::Length(14),            // Model
+                    Constraint::Length(14),            // Context
                     Constraint::Min(12),               // Last Active
                 ];
 
@@ -306,10 +323,14 @@ struct JsonlSummary {
 /// Read model, branch, and total tokens from the last assistant entry in a JSONL file.
 /// Seeks to the tail of large files to avoid reading the entire file into memory.
 fn read_jsonl_summary(path: &std::path::Path) -> JsonlSummary {
-    use std::io::{BufReader, Seek, SeekFrom};
     use crate::session::read_line_capped;
+    use std::io::{BufReader, Seek, SeekFrom};
 
-    let empty = JsonlSummary { model: None, branch: None, tokens: 0 };
+    let empty = JsonlSummary {
+        model: None,
+        branch: None,
+        tokens: 0,
+    };
     let file = match fs::File::open(path) {
         Ok(f) => f,
         Err(_) => return empty,
@@ -358,7 +379,10 @@ fn read_jsonl_summary(path: &std::path::Path) -> JsonlSummary {
         // Pick up gitBranch from any recent entry
         if branch.is_none() && line.contains("\"gitBranch\"") {
             if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
-                branch = v.get("gitBranch").and_then(|b| b.as_str()).map(|s| s.to_string());
+                branch = v
+                    .get("gitBranch")
+                    .and_then(|b| b.as_str())
+                    .map(|s| s.to_string());
             }
         }
 
@@ -366,14 +390,33 @@ fn read_jsonl_summary(path: &std::path::Path) -> JsonlSummary {
             if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
                 if let Some(msg) = v.get("message") {
                     if model.is_none() {
-                        model = msg.get("model").and_then(|m| m.as_str()).map(|s| s.to_string());
+                        model = msg
+                            .get("model")
+                            .and_then(|m| m.as_str())
+                            .map(|s| s.to_string());
                     }
                     if input_tokens == 0 {
                         if let Some(usage) = msg.get("usage") {
-                            input_tokens = usage.get("input_tokens").and_then(|t| t.as_u64()).unwrap_or(0)
-                                .saturating_add(usage.get("cache_creation_input_tokens").and_then(|t| t.as_u64()).unwrap_or(0))
-                                .saturating_add(usage.get("cache_read_input_tokens").and_then(|t| t.as_u64()).unwrap_or(0));
-                            output_tokens = usage.get("output_tokens").and_then(|t| t.as_u64()).unwrap_or(0);
+                            input_tokens = usage
+                                .get("input_tokens")
+                                .and_then(|t| t.as_u64())
+                                .unwrap_or(0)
+                                .saturating_add(
+                                    usage
+                                        .get("cache_creation_input_tokens")
+                                        .and_then(|t| t.as_u64())
+                                        .unwrap_or(0),
+                                )
+                                .saturating_add(
+                                    usage
+                                        .get("cache_read_input_tokens")
+                                        .and_then(|t| t.as_u64())
+                                        .unwrap_or(0),
+                                );
+                            output_tokens = usage
+                                .get("output_tokens")
+                                .and_then(|t| t.as_u64())
+                                .unwrap_or(0);
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,13 @@ fn main() -> io::Result<()> {
                 tmux::switch_to_pane(&name);
             }
         }
-        Some(Command::Launch { name, cwd, command, attach, tag }) => {
+        Some(Command::Launch {
+            name,
+            cwd,
+            command,
+            attach,
+            tag,
+        }) => {
             let (default_name, default_cwd) = tmux::default_new_session_info();
             let session_name = name.as_deref().unwrap_or(&default_name);
             let session_cwd = cwd.as_deref().unwrap_or(&default_cwd);
@@ -52,7 +58,11 @@ fn main() -> io::Result<()> {
                 }
             }
         }
-        Some(Command::Resume { id, name, no_attach }) => {
+        Some(Command::Resume {
+            id,
+            name,
+            no_attach,
+        }) => {
             if let Some(session_id) = id {
                 match tmux::resume_session(&session_id, name.as_deref()) {
                     Ok(sess) => {
@@ -85,7 +95,11 @@ fn main() -> io::Result<()> {
         Some(Command::Next) => {
             let mut app = App::new();
             app.refresh();
-            if let Some(session) = app.sessions.iter().find(|s| s.status == session::SessionStatus::Input) {
+            if let Some(session) = app
+                .sessions
+                .iter()
+                .find(|s| s.status == session::SessionStatus::Input)
+            {
                 if let Some(target) = &session.pane_target {
                     tmux::switch_to_pane(target);
                 }
@@ -102,7 +116,11 @@ fn main() -> io::Result<()> {
             } else {
                 match config::config_path() {
                     Some(p) => {
-                        let exists = if p.exists() { "" } else { " (not present — using defaults)" };
+                        let exists = if p.exists() {
+                            ""
+                        } else {
+                            " (not present — using defaults)"
+                        };
                         println!("Config file: {}{exists}", p.display());
                     }
                     None => println!("Could not determine config directory."),
@@ -173,11 +191,9 @@ fn run_app(
         if app.view_mode == ViewMode::View {
             view_ui::resolve_zoom(&mut app);
         }
-        terminal.draw(|f| {
-            match app.view_mode {
-                ViewMode::Table => ui::render(f, &app),
-                ViewMode::View => view_ui::render(f, &app),
-            }
+        terminal.draw(|f| match app.view_mode {
+            ViewMode::Table => ui::render(f, &app),
+            ViewMode::View => view_ui::render(f, &app),
         })?;
 
         app.advance_tick();

--- a/src/new_session.rs
+++ b/src/new_session.rs
@@ -2,11 +2,11 @@ use std::io;
 
 use crossterm::event::{self, Event, KeyCode, KeyModifiers};
 use ratatui::{
-    Frame,
     layout::{Constraint, Layout},
     style::{Color, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
+    Frame,
 };
 
 use crate::tmux;
@@ -87,30 +87,26 @@ impl NewSessionForm {
                     Err(_) => self.result = Some(String::new()),
                 }
             }
-            KeyCode::Tab | KeyCode::Down => {
-                match self.active {
-                    Field::Name => {
-                        self.active = Field::Cwd;
-                        self.cursor_pos = self.cwd.len();
-                    }
-                    Field::Cwd => {
-                        self.active = Field::Name;
-                        self.cursor_pos = self.name.len();
-                    }
+            KeyCode::Tab | KeyCode::Down => match self.active {
+                Field::Name => {
+                    self.active = Field::Cwd;
+                    self.cursor_pos = self.cwd.len();
                 }
-            }
-            KeyCode::BackTab | KeyCode::Up => {
-                match self.active {
-                    Field::Name => {
-                        self.active = Field::Cwd;
-                        self.cursor_pos = self.cwd.len();
-                    }
-                    Field::Cwd => {
-                        self.active = Field::Name;
-                        self.cursor_pos = self.name.len();
-                    }
+                Field::Cwd => {
+                    self.active = Field::Name;
+                    self.cursor_pos = self.name.len();
                 }
-            }
+            },
+            KeyCode::BackTab | KeyCode::Up => match self.active {
+                Field::Name => {
+                    self.active = Field::Cwd;
+                    self.cursor_pos = self.cwd.len();
+                }
+                Field::Cwd => {
+                    self.active = Field::Name;
+                    self.cursor_pos = self.name.len();
+                }
+            },
             KeyCode::Backspace => {
                 let pos = self.cursor_pos;
                 if pos > 0 {

--- a/src/park.rs
+++ b/src/park.rs
@@ -17,7 +17,12 @@ struct ParkedSession {
 }
 
 fn park_file_path() -> Option<std::path::PathBuf> {
-    dirs::home_dir().map(|h| h.join(".local").join("state").join("recon").join("parked.json"))
+    dirs::home_dir().map(|h| {
+        h.join(".local")
+            .join("state")
+            .join("recon")
+            .join("parked.json")
+    })
 }
 
 pub fn park() {

--- a/src/session.rs
+++ b/src/session.rs
@@ -220,7 +220,12 @@ pub fn discover_sessions(prev_sessions: &HashMap<String, Session>) -> Vec<Sessio
             // started in one CWD then moved to a worktree). Prefer the larger file.
             if matched_session_ids.contains(&session_id) {
                 if let Some(existing) = sessions.iter_mut().find(|s| s.session_id == session_id) {
-                    let existing_size = existing.jsonl_path.metadata().ok().map(|m| m.len()).unwrap_or(0);
+                    let existing_size = existing
+                        .jsonl_path
+                        .metadata()
+                        .ok()
+                        .map(|m| m.len())
+                        .unwrap_or(0);
                     let new_size = path.metadata().ok().map(|m| m.len()).unwrap_or(0);
                     if new_size > existing_size {
                         let prev = prev_sessions.get(&session_id);
@@ -233,7 +238,8 @@ pub fn discover_sessions(prev_sessions: &HashMap<String, Session>) -> Vec<Sessio
                             prev.and_then(|s| s.effort.clone()),
                             prev.and_then(|s| s.last_activity.clone()),
                         );
-                        let cwd = info.cwd
+                        let cwd = info
+                            .cwd
                             .or_else(|| prev.map(|s| s.cwd.clone()))
                             .unwrap_or_else(|| decode_project_path(&project_dir));
                         let (project_name, relative_dir, branch) = git_project_info(&cwd);
@@ -316,10 +322,8 @@ pub fn discover_sessions(prev_sessions: &HashMap<String, Session>) -> Vec<Sessio
     // hide the second instance. PID is the unique identifier per Claude process,
     // so each instance gets its own stable entry in the table — even if the TUI
     // shows duplicate session names.
-    let known_pids: std::collections::HashSet<i32> = sessions
-        .iter()
-        .filter_map(|s| s.pid)
-        .collect();
+    let known_pids: std::collections::HashSet<i32> =
+        sessions.iter().filter_map(|s| s.pid).collect();
 
     for (session_id_key, live) in &live_map {
         if known_pids.contains(&live.pid) {
@@ -535,7 +539,11 @@ fn git_project_info(cwd: &str) -> (String, Option<String>, Option<String>) {
         let cache = GIT_CACHE.lock().unwrap();
         if let Some(info) = cache.as_ref().and_then(|c| c.get(cwd)) {
             if info.fetched_at.elapsed() < GIT_CACHE_TTL {
-                return (info.repo_name.clone(), info.relative_dir.clone(), info.branch.clone());
+                return (
+                    info.repo_name.clone(),
+                    info.relative_dir.clone(),
+                    info.branch.clone(),
+                );
             }
         }
     }
@@ -591,7 +599,9 @@ fn fetch_canonical_repo_name(cwd: &str) -> Option<String> {
     } else {
         &resolved
     };
-    repo_root.file_name().map(|n| n.to_string_lossy().to_string())
+    repo_root
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
 }
 
 fn fetch_git_branch(cwd: &str) -> Option<String> {
@@ -655,8 +665,7 @@ fn decode_project_path(project_dir: &Path) -> String {
     // Convert back: leading - becomes /, internal - becomes /
     // This is lossy (can't distinguish original - from / or . or _) but good enough
     if name.starts_with('-') {
-        name.replacen('-', "/", 1)
-            .replace('-', "/")
+        name.replacen('-', "/", 1).replace('-', "/")
     } else {
         name
     }
@@ -817,7 +826,8 @@ fn parse_jsonl(
                 // Extract effort if present ("with <effort> effort")
                 let (model_part, new_effort) = if let Some(wp) = remainder.find("with ") {
                     let after_with = &remainder[wp + 5..];
-                    let eff = after_with.find(" effort")
+                    let eff = after_with
+                        .find(" effort")
                         .map(|end| after_with[..end].trim().to_string())
                         .filter(|s| !s.is_empty());
                     (&remainder[..wp], eff)
@@ -938,7 +948,10 @@ fn read_tmux_tags(session_name: &str) -> HashMap<String, String> {
     read_tmux_env(session_name, "RECON_TAGS")
         .map(|val| {
             val.split(',')
-                .filter_map(|tag| tag.split_once(':').map(|(k, v)| (k.to_string(), v.to_string())))
+                .filter_map(|tag| {
+                    tag.split_once(':')
+                        .map(|(k, v)| (k.to_string(), v.to_string()))
+                })
                 .collect()
         })
         .unwrap_or_default()
@@ -970,17 +983,23 @@ fn strip_ansi(s: &str) -> String {
         if c == '\x1b' {
             // Raw ESC byte: skip until 'm'
             for next in chars.by_ref() {
-                if next == 'm' { break; }
+                if next == 'm' {
+                    break;
+                }
             }
         } else if c == '\\' && chars.peek() == Some(&'u') {
             // Check for JSON-escaped \\u001b
             let rest: String = chars.clone().take(5).collect();
             if rest.starts_with("u001b") || rest.starts_with("u001B") {
                 // Consume "u001b" (5 chars)
-                for _ in 0..5 { chars.next(); }
+                for _ in 0..5 {
+                    chars.next();
+                }
                 // Skip the ANSI parameter sequence until 'm'
                 for next in chars.by_ref() {
-                    if next == 'm' { break; }
+                    if next == 'm' {
+                        break;
+                    }
                 }
             } else {
                 result.push(c);
@@ -1072,7 +1091,12 @@ pub fn find_session_cwd(session_id: &str) -> Option<String> {
 /// - Working: JSONL modified in last 5s
 /// - Input: last activity within 10 minutes (active conversation, waiting for user)
 /// - Idle: last activity older than 10 minutes
-fn determine_status(_path: &Path, input_tokens: u64, output_tokens: u64, pane_target: Option<&str>) -> SessionStatus {
+fn determine_status(
+    _path: &Path,
+    input_tokens: u64,
+    output_tokens: u64,
+    pane_target: Option<&str>,
+) -> SessionStatus {
     // tmux pane content is the source of truth for active sessions
     if let Some(target) = pane_target {
         let pane = pane_status(target);
@@ -1129,7 +1153,8 @@ fn pane_status(pane_target: &str) -> SessionStatus {
         }
 
         // Input: selection-style permission prompts ("❯ N.")
-        if let Some(pos) = trimmed.find('\u{276F}') { // ❯
+        if let Some(pos) = trimmed.find('\u{276F}') {
+            // ❯
             let after = trimmed[pos + '\u{276F}'.len_utf8()..].trim_start();
             if after.starts_with(|c: char| c.is_ascii_digit()) {
                 return SessionStatus::Input;
@@ -1149,10 +1174,12 @@ fn pane_status(pane_target: &str) -> SessionStatus {
 /// Covers dingbat spinners (✽✢✳✶✻ etc.), record symbol (⏺),
 /// and middle dot (·) used for progress lines.
 fn is_spinner(c: char) -> bool {
-    matches!(c,
-        '\u{2720}'..='\u{2767}' | // Dingbats: ✽✢✳✶✻✺✴✵ etc.
+    matches!(
+        c,
+        '\u{2720}'
+            ..='\u{2767}' | // Dingbats: ✽✢✳✶✻✺✴✵ etc.
         '\u{23FA}'              | // ⏺ (record)
-        '\u{00B7}'                // · (middle dot, used for progress)
+        '\u{00B7}' // · (middle dot, used for progress)
     )
 }
 
@@ -1185,10 +1212,7 @@ fn read_pid_session_map() -> HashMap<i32, SessionFileInfo> {
                         v.get("pid").and_then(|p| p.as_i64()),
                         v.get("sessionId").and_then(|s| s.as_str()),
                     ) {
-                        let started_at = v
-                            .get("startedAt")
-                            .and_then(|s| s.as_u64())
-                            .unwrap_or(0);
+                        let started_at = v.get("startedAt").and_then(|s| s.as_u64()).unwrap_or(0);
                         map.insert(
                             pid as i32,
                             SessionFileInfo {
@@ -1403,4 +1427,3 @@ mod tests {
         assert!(validate_cwd("/tmp"));
     }
 }
-

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -22,7 +22,12 @@ pub fn switch_to_pane(target: &str) {
 /// and passes the parts as the binary + args to tmux (no shell wrapper, so aliases
 /// won't resolve — use full paths).
 /// Returns the session name on success.
-pub fn create_session(name: &str, cwd: &str, command: Option<&str>, tags: &[String]) -> Result<String, String> {
+pub fn create_session(
+    name: &str,
+    cwd: &str,
+    command: Option<&str>,
+    tags: &[String],
+) -> Result<String, String> {
     if !session::validate_cwd(cwd) {
         return Err(format!("Invalid working directory: {cwd}"));
     }
@@ -84,7 +89,11 @@ pub fn resume_session(session_id: &str, name: Option<&str>) -> Result<String, St
     // Validate before use — fall back to current dir if the JSONL cwd is invalid.
     let cwd = session::find_session_cwd(session_id)
         .filter(|c| session::validate_cwd(c))
-        .or_else(|| std::env::current_dir().map(|p| p.to_string_lossy().to_string()).ok())
+        .or_else(|| {
+            std::env::current_dir()
+                .map(|p| p.to_string_lossy().to_string())
+                .ok()
+        })
         .unwrap_or_else(|| ".".to_string());
 
     let base_name = sanitize_session_name(&tmux_name);
@@ -157,7 +166,11 @@ fn session_exists(name: &str) -> bool {
 fn which_claude() -> Option<String> {
     let output = Command::new("which").arg("claude").output().ok()?;
     let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if path.is_empty() { None } else { Some(path) }
+    if path.is_empty() {
+        None
+    } else {
+        Some(path)
+    }
 }
 
 /// Kill a tmux session by name.
@@ -175,7 +188,13 @@ pub fn kill_session(name: &str) -> bool {
 fn sanitize_session_name(name: &str) -> String {
     let sanitized: String = name
         .chars()
-        .map(|c| if c.is_alphanumeric() || c == '_' { c } else { '-' })
+        .map(|c| {
+            if c.is_alphanumeric() || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
         .collect();
 
     let trimmed = sanitized.trim_start_matches('-');

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,9 +1,9 @@
 use ratatui::{
-    Frame,
     layout::{Constraint, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Cell, Row, Table, Paragraph},
+    widgets::{Block, Borders, Cell, Paragraph, Row, Table},
+    Frame,
 };
 
 use crate::app::App;
@@ -20,11 +20,7 @@ pub fn render(frame: &mut Frame, app: &App) {
         ])
         .split(frame.area())
     } else {
-        Layout::vertical([
-            Constraint::Min(1),
-            Constraint::Length(1),
-        ])
-        .split(frame.area())
+        Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(frame.area())
     };
 
     render_table(frame, app, chunks[0]);
@@ -76,13 +72,11 @@ fn render_table(frame: &mut Frame, app: &App, area: Rect) {
     let mut widths = vec![Constraint::Length(4)]; // #
     widths.extend(columns.iter().map(|c| column_constraint(*c, app)));
 
-    let table = Table::new(rows, widths)
-        .header(header)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(" recon — Claude Code Sessions "),
-        );
+    let table = Table::new(rows, widths).header(header).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(" recon — Claude Code Sessions "),
+    );
 
     frame.render_widget(table, area);
 }

--- a/src/view_ui.rs
+++ b/src/view_ui.rs
@@ -1,11 +1,11 @@
 use std::collections::BTreeMap;
 
 use ratatui::{
-    Frame,
     layout::{Alignment, Constraint, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Padding, Paragraph},
+    Frame,
 };
 
 use crate::app::App;
@@ -30,157 +30,157 @@ type Palette = &'static [(u8, u8, u8)]; // index 0 unused (transparent)
 
 // Egg palette: 1=cream shell, 2=shadow, 3=green spots
 const PAL_EGG: &[(u8, u8, u8)] = &[
-    (0, 0, 0),         // 0: unused
-    (255, 250, 230),    // 1: cream shell
-    (220, 200, 170),    // 2: shell shadow
-    (180, 220, 180),    // 3: green spots
+    (0, 0, 0),       // 0: unused
+    (255, 250, 230), // 1: cream shell
+    (220, 200, 170), // 2: shell shadow
+    (180, 220, 180), // 3: green spots
 ];
 
 const SPRITE_EGG: [Sprite; 1] = [[
-    [0,0,0,0,1,1,1,0,0,0],
-    [0,0,0,1,1,1,1,1,0,0],
-    [0,0,1,1,1,3,1,1,1,0],
-    [0,0,1,1,1,1,1,1,1,0],
-    [0,0,1,3,1,1,1,3,1,0],
-    [0,0,1,1,1,1,1,1,1,0],
-    [0,0,1,1,1,1,1,1,1,0],
-    [0,0,0,1,2,1,2,1,0,0],
-    [0,0,0,0,1,1,1,0,0,0],
-    [0,0,0,0,0,0,0,0,0,0],
+    [0, 0, 0, 0, 1, 1, 1, 0, 0, 0],
+    [0, 0, 0, 1, 1, 1, 1, 1, 0, 0],
+    [0, 0, 1, 1, 1, 3, 1, 1, 1, 0],
+    [0, 0, 1, 1, 1, 1, 1, 1, 1, 0],
+    [0, 0, 1, 3, 1, 1, 1, 3, 1, 0],
+    [0, 0, 1, 1, 1, 1, 1, 1, 1, 0],
+    [0, 0, 1, 1, 1, 1, 1, 1, 1, 0],
+    [0, 0, 0, 1, 2, 1, 2, 1, 0, 0],
+    [0, 0, 0, 0, 1, 1, 1, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
 ]];
 
 // Working palette: 1=green body, 2=dark green, 3=eyes, 4=eye highlight,
 //                  5=blush, 6=mouth, 7=feet, 8=sparkle
 const PAL_WORKING: &[(u8, u8, u8)] = &[
     (0, 0, 0),
-    (120, 220, 120),    // 1: green body
-    (80, 180, 80),      // 2: darker green
-    (40, 40, 40),       // 3: eyes
-    (255, 255, 255),    // 4: eye highlight
-    (255, 150, 150),    // 5: cheeks
-    (200, 100, 80),     // 6: mouth
-    (100, 200, 100),    // 7: feet
-    (255, 220, 60),     // 8: sparkle
+    (120, 220, 120), // 1: green body
+    (80, 180, 80),   // 2: darker green
+    (40, 40, 40),    // 3: eyes
+    (255, 255, 255), // 4: eye highlight
+    (255, 150, 150), // 5: cheeks
+    (200, 100, 80),  // 6: mouth
+    (100, 200, 100), // 7: feet
+    (255, 220, 60),  // 8: sparkle
 ];
 
 const SPRITE_WORKING: [Sprite; 3] = [
     // Frame 0: happy, sparkles top
     [
-        [0,0,0,8,1,1,1,8,0,0],
-        [0,0,1,1,1,1,1,1,0,0],
-        [0,1,1,1,1,1,1,1,1,0],
-        [0,1,3,4,1,1,3,4,1,0],
-        [0,1,1,1,1,1,1,1,1,0],
-        [0,5,1,1,6,6,1,1,5,0],
-        [0,1,1,1,1,1,1,1,1,0],
-        [0,0,1,1,1,1,1,1,0,0],
-        [0,0,0,7,0,0,7,0,0,0],
-        [0,0,0,0,0,0,0,0,0,0],
+        [0, 0, 0, 8, 1, 1, 1, 8, 0, 0],
+        [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+        [0, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+        [0, 1, 3, 4, 1, 1, 3, 4, 1, 0],
+        [0, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+        [0, 5, 1, 1, 6, 6, 1, 1, 5, 0],
+        [0, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+        [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+        [0, 0, 0, 7, 0, 0, 7, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     ],
     // Frame 1: squinting
     [
-        [0,0,0,1,1,1,1,0,0,0],
-        [0,0,1,1,1,1,1,1,0,0],
-        [0,1,1,1,1,1,1,1,1,0],
-        [0,1,1,3,1,1,3,1,1,0],
-        [0,1,1,1,1,1,1,1,1,0],
-        [0,5,1,6,1,1,6,1,5,0],
-        [0,1,1,1,1,1,1,1,1,0],
-        [0,0,1,1,1,1,1,1,0,0],
-        [0,0,7,0,0,0,0,7,0,0],
-        [0,0,0,0,0,0,0,0,0,0],
+        [0, 0, 0, 1, 1, 1, 1, 0, 0, 0],
+        [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+        [0, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+        [0, 1, 1, 3, 1, 1, 3, 1, 1, 0],
+        [0, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+        [0, 5, 1, 6, 1, 1, 6, 1, 5, 0],
+        [0, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+        [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+        [0, 0, 7, 0, 0, 0, 0, 7, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     ],
     // Frame 2: arms out, sparkles
     [
-        [0,0,8,1,1,1,1,8,0,0],
-        [0,0,1,1,1,1,1,1,0,0],
-        [0,1,1,1,1,1,1,1,1,0],
-        [0,1,4,3,1,1,4,3,1,0],
-        [0,1,1,1,1,1,1,1,1,0],
-        [0,5,1,1,6,6,1,1,5,0],
-        [8,1,1,1,1,1,1,1,1,8],
-        [0,0,1,1,1,1,1,1,0,0],
-        [0,0,0,7,0,0,7,0,0,0],
-        [0,0,0,0,0,0,0,0,0,0],
+        [0, 0, 8, 1, 1, 1, 1, 8, 0, 0],
+        [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+        [0, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+        [0, 1, 4, 3, 1, 1, 4, 3, 1, 0],
+        [0, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+        [0, 5, 1, 1, 6, 6, 1, 1, 5, 0],
+        [8, 1, 1, 1, 1, 1, 1, 1, 1, 8],
+        [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+        [0, 0, 0, 7, 0, 0, 7, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     ],
 ];
 
 // Idle palette: 1=blue-grey body, 2=darker, 3=closed eyes, 4=highlight, 5=feet, 6=Zzz
 const PAL_IDLE: &[(u8, u8, u8)] = &[
     (0, 0, 0),
-    (140, 160, 200),    // 1: blue-grey body
-    (110, 130, 170),    // 2: darker
-    (60, 60, 80),       // 3: closed eyes
-    (180, 190, 220),    // 4: highlight
-    (120, 140, 180),    // 5: feet
-    (200, 200, 255),    // 6: Zzz
+    (140, 160, 200), // 1: blue-grey body
+    (110, 130, 170), // 2: darker
+    (60, 60, 80),    // 3: closed eyes
+    (180, 190, 220), // 4: highlight
+    (120, 140, 180), // 5: feet
+    (200, 200, 255), // 6: Zzz
 ];
 
 const SPRITE_IDLE: [Sprite; 1] = [[
-    [0,0,0,1,1,1,1,0,0,0],
-    [0,0,1,1,1,1,1,1,0,6],
-    [0,1,1,1,1,1,1,1,1,0],
-    [0,1,3,3,1,1,3,3,1,6],
-    [0,1,1,1,1,1,1,1,1,0],
-    [0,1,1,1,1,1,1,1,1,0],
-    [0,1,1,1,1,1,1,1,1,0],
-    [0,0,1,1,1,1,1,1,0,0],
-    [0,0,0,5,0,0,5,0,0,0],
-    [0,0,0,0,0,0,0,0,0,0],
+    [0, 0, 0, 1, 1, 1, 1, 0, 0, 0],
+    [0, 0, 1, 1, 1, 1, 1, 1, 0, 6],
+    [0, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+    [0, 1, 3, 3, 1, 1, 3, 3, 1, 6],
+    [0, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+    [0, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+    [0, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+    [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+    [0, 0, 0, 5, 0, 0, 5, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
 ]];
 
 // Input (angry) palette: 1=orange body, 2=darker, 3=pupils, 4=eye whites,
 //                        5=angry red, 6=feet, 7=flush
 const PAL_INPUT: &[(u8, u8, u8)] = &[
     (0, 0, 0),
-    (255, 180, 60),     // 1: orange body
-    (220, 150, 40),     // 2: darker
-    (40, 40, 40),       // 3: pupils
-    (255, 255, 255),    // 4: eye whites
-    (255, 60, 60),      // 5: angry red (brows, mouth)
-    (200, 140, 40),     // 6: feet
-    (255, 100, 100),    // 7: flush/anger
+    (255, 180, 60),  // 1: orange body
+    (220, 150, 40),  // 2: darker
+    (40, 40, 40),    // 3: pupils
+    (255, 255, 255), // 4: eye whites
+    (255, 60, 60),   // 5: angry red (brows, mouth)
+    (200, 140, 40),  // 6: feet
+    (255, 100, 100), // 7: flush/anger
 ];
 
 const SPRITE_INPUT: [Sprite; 3] = [
     // Frame 0: angry brows down
     [
-        [0,0,0,1,1,1,1,0,0,0],
-        [0,0,1,1,1,1,1,1,0,0],
-        [0,1,5,1,1,1,1,5,1,0],
-        [0,1,1,4,3,3,4,1,1,0],
-        [0,7,1,1,1,1,1,1,7,0],
-        [0,1,1,5,5,5,5,1,1,0],
-        [0,1,1,1,1,1,1,1,1,0],
-        [0,0,1,1,1,1,1,1,0,0],
-        [0,0,0,6,0,0,6,0,0,0],
-        [0,0,0,0,0,0,0,0,0,0],
+        [0, 0, 0, 1, 1, 1, 1, 0, 0, 0],
+        [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+        [0, 1, 5, 1, 1, 1, 1, 5, 1, 0],
+        [0, 1, 1, 4, 3, 3, 4, 1, 1, 0],
+        [0, 7, 1, 1, 1, 1, 1, 1, 7, 0],
+        [0, 1, 1, 5, 5, 5, 5, 1, 1, 0],
+        [0, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+        [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+        [0, 0, 0, 6, 0, 0, 6, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     ],
     // Frame 1: brows shifted
     [
-        [0,0,0,1,1,1,1,0,0,0],
-        [0,0,1,1,1,1,1,1,0,0],
-        [0,1,1,5,1,1,5,1,1,0],
-        [0,1,1,4,3,3,4,1,1,0],
-        [0,7,1,1,1,1,1,1,7,0],
-        [0,1,1,1,5,5,1,1,1,0],
-        [0,1,1,1,1,1,1,1,1,0],
-        [0,0,1,1,1,1,1,1,0,0],
-        [0,0,6,0,0,0,0,6,0,0],
-        [0,0,0,0,0,0,0,0,0,0],
+        [0, 0, 0, 1, 1, 1, 1, 0, 0, 0],
+        [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+        [0, 1, 1, 5, 1, 1, 5, 1, 1, 0],
+        [0, 1, 1, 4, 3, 3, 4, 1, 1, 0],
+        [0, 7, 1, 1, 1, 1, 1, 1, 7, 0],
+        [0, 1, 1, 1, 5, 5, 1, 1, 1, 0],
+        [0, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+        [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+        [0, 0, 6, 0, 0, 0, 0, 6, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     ],
     // Frame 2: wider stance
     [
-        [0,0,0,1,1,1,1,0,0,0],
-        [0,0,1,1,1,1,1,1,0,0],
-        [0,1,5,1,1,1,1,5,1,0],
-        [0,1,1,3,4,4,3,1,1,0],
-        [0,1,7,1,1,1,1,7,1,0],
-        [0,1,5,1,5,5,1,5,1,0],
-        [0,1,1,1,1,1,1,1,1,0],
-        [0,0,1,1,1,1,1,1,0,0],
-        [0,0,0,6,0,0,6,0,0,0],
-        [0,0,0,0,0,0,0,0,0,0],
+        [0, 0, 0, 1, 1, 1, 1, 0, 0, 0],
+        [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+        [0, 1, 5, 1, 1, 1, 1, 5, 1, 0],
+        [0, 1, 1, 3, 4, 4, 3, 1, 1, 0],
+        [0, 1, 7, 1, 1, 1, 1, 7, 1, 0],
+        [0, 1, 5, 1, 5, 5, 1, 5, 1, 0],
+        [0, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+        [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+        [0, 0, 0, 6, 0, 0, 6, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     ],
 ];
 
@@ -388,8 +388,7 @@ pub fn render(frame: &mut Frame, app: &App) {
         ])
         .split(frame.area())
     } else {
-        Layout::vertical([Constraint::Min(1), Constraint::Length(1)])
-            .split(frame.area())
+        Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(frame.area())
     };
 
     render_rooms(frame, app, chunks[0]);
@@ -439,18 +438,13 @@ fn render_rooms(frame: &mut Frame, app: &App, area: Rect) {
     let total_pages = (rooms.len() + ROOMS_PER_PAGE - 1) / ROOMS_PER_PAGE;
     let page = app.view_page.min(total_pages.saturating_sub(1));
     let page_start = page * ROOMS_PER_PAGE;
-    let page_rooms: Vec<&Room> = rooms
-        .iter()
-        .skip(page_start)
-        .take(ROOMS_PER_PAGE)
-        .collect();
+    let page_rooms: Vec<&Room> = rooms.iter().skip(page_start).take(ROOMS_PER_PAGE).collect();
 
-    let v_chunks = Layout::vertical([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
-        .split(area);
-    let top_h = Layout::horizontal([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
-        .split(v_chunks[0]);
-    let bot_h = Layout::horizontal([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
-        .split(v_chunks[1]);
+    let v_chunks = Layout::vertical([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)]).split(area);
+    let top_h =
+        Layout::horizontal([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)]).split(v_chunks[0]);
+    let bot_h =
+        Layout::horizontal([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)]).split(v_chunks[1]);
     let cells = [top_h[0], top_h[1], bot_h[0], bot_h[1]];
 
     for (i, cell) in cells.iter().enumerate() {
@@ -465,9 +459,20 @@ fn render_rooms(frame: &mut Frame, app: &App, area: Rect) {
     }
 }
 
-fn render_room(frame: &mut Frame, app: &App, room: &Room, area: Rect, slot_num: Option<usize>, selected_agent: Option<usize>) {
+fn render_room(
+    frame: &mut Frame,
+    app: &App,
+    room: &Room,
+    area: Rect,
+    slot_num: Option<usize>,
+    selected_agent: Option<usize>,
+) {
     let border_color = if room.has_input {
-        if app.tick % 2 == 0 { Color::Yellow } else { Color::White }
+        if app.tick % 2 == 0 {
+            Color::Yellow
+        } else {
+            Color::White
+        }
     } else {
         Color::DarkGray
     };
@@ -529,12 +534,24 @@ fn render_room(frame: &mut Frame, app: &App, room: &Room, area: Rect, slot_num: 
             }
             let flat_idx = row_idx * chars_per_row + col_idx;
             let is_selected = selected_agent == Some(flat_idx);
-            render_character(frame, &app.sessions[session_idx], h_chunks[col_idx], app.tick, is_selected);
+            render_character(
+                frame,
+                &app.sessions[session_idx],
+                h_chunks[col_idx],
+                app.tick,
+                is_selected,
+            );
         }
     }
 }
 
-fn render_character(frame: &mut Frame, session: &Session, area: Rect, tick: u64, is_selected: bool) {
+fn render_character(
+    frame: &mut Frame,
+    session: &Session,
+    area: Rect,
+    tick: u64,
+    is_selected: bool,
+) {
     if area.height < 3 || area.width < 4 {
         return;
     }
@@ -545,15 +562,18 @@ fn render_character(frame: &mut Frame, session: &Session, area: Rect, tick: u64,
     let ratio = session.token_ratio();
 
     let color = if session.status == SessionStatus::Input {
-        if tick % 2 == 0 { Color::Yellow } else { Color::White }
+        if tick % 2 == 0 {
+            Color::Yellow
+        } else {
+            Color::White
+        }
     } else {
         status_color(&session.status)
     };
 
     // Selection highlight background
     if is_selected {
-        let bg = Block::default()
-            .style(Style::default().bg(Color::Rgb(40, 40, 60)));
+        let bg = Block::default().style(Style::default().bg(Color::Rgb(40, 40, 60)));
         frame.render_widget(bg, area);
     }
 
@@ -566,7 +586,9 @@ fn render_character(frame: &mut Frame, session: &Session, area: Rect, tick: u64,
     // Session name
     let name = session.tmux_session.as_deref().unwrap_or("???");
     let name_style = if is_selected {
-        Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(Color::White)
     };
@@ -752,8 +774,16 @@ mod tests {
     #[test]
     fn input_rooms_also_sorted_by_activity() {
         let sessions = vec![
-            make_session("/old-input", SessionStatus::Input, Some("2026-03-16T08:00:00Z")),
-            make_session("/new-input", SessionStatus::Input, Some("2026-03-16T12:00:00Z")),
+            make_session(
+                "/old-input",
+                SessionStatus::Input,
+                Some("2026-03-16T08:00:00Z"),
+            ),
+            make_session(
+                "/new-input",
+                SessionStatus::Input,
+                Some("2026-03-16T12:00:00Z"),
+            ),
         ];
         let all: Vec<usize> = (0..sessions.len()).collect();
         let rooms = group_into_rooms(&sessions, &all);
@@ -764,9 +794,17 @@ mod tests {
     #[test]
     fn worktrees_share_room_by_project_name() {
         // Two sessions with different CWDs but same project_name should be in the same room
-        let mut s1 = make_session("/repos/line5", SessionStatus::Idle, Some("2026-03-16T10:00:00Z"));
+        let mut s1 = make_session(
+            "/repos/line5",
+            SessionStatus::Idle,
+            Some("2026-03-16T10:00:00Z"),
+        );
         s1.project_name = "line5".to_string();
-        let mut s2 = make_session("/worktrees/line5-feat", SessionStatus::Working, Some("2026-03-16T11:00:00Z"));
+        let mut s2 = make_session(
+            "/worktrees/line5-feat",
+            SessionStatus::Working,
+            Some("2026-03-16T11:00:00Z"),
+        );
         s2.project_name = "line5".to_string();
         let sessions = [s1, s2];
         let all: Vec<usize> = (0..sessions.len()).collect();
@@ -779,9 +817,17 @@ mod tests {
     #[test]
     fn subproject_gets_separate_room() {
         // Root and subproject should be different rooms
-        let mut s1 = make_session("/repos/line5", SessionStatus::Idle, Some("2026-03-16T10:00:00Z"));
+        let mut s1 = make_session(
+            "/repos/line5",
+            SessionStatus::Idle,
+            Some("2026-03-16T10:00:00Z"),
+        );
         s1.project_name = "line5".to_string();
-        let mut s2 = make_session("/repos/line5/tools/solo", SessionStatus::Idle, Some("2026-03-16T11:00:00Z"));
+        let mut s2 = make_session(
+            "/repos/line5/tools/solo",
+            SessionStatus::Idle,
+            Some("2026-03-16T11:00:00Z"),
+        );
         s2.project_name = "line5".to_string();
         s2.relative_dir = Some("tools/solo".to_string());
         let sessions = [s1, s2];
@@ -793,16 +839,28 @@ mod tests {
     #[test]
     fn mixed_input_and_activity_sorting() {
         let sessions = vec![
-            make_session("/idle-recent", SessionStatus::Idle, Some("2026-03-16T15:00:00Z")),
-            make_session("/input-old", SessionStatus::Input, Some("2026-03-16T08:00:00Z")),
+            make_session(
+                "/idle-recent",
+                SessionStatus::Idle,
+                Some("2026-03-16T15:00:00Z"),
+            ),
+            make_session(
+                "/input-old",
+                SessionStatus::Input,
+                Some("2026-03-16T08:00:00Z"),
+            ),
             make_session("/egg", SessionStatus::New, None),
-            make_session("/idle-old", SessionStatus::Idle, Some("2026-03-16T09:00:00Z")),
+            make_session(
+                "/idle-old",
+                SessionStatus::Idle,
+                Some("2026-03-16T09:00:00Z"),
+            ),
         ];
         let all: Vec<usize> = (0..sessions.len()).collect();
         let rooms = group_into_rooms(&sessions, &all);
-        assert_eq!(rooms[0].name, "/input-old");   // input first regardless of activity
-        assert_eq!(rooms[1].name, "/idle-recent");  // most recent activity
-        assert_eq!(rooms[2].name, "/idle-old");     // older activity
-        assert_eq!(rooms[3].name, "/egg");           // no activity last
+        assert_eq!(rooms[0].name, "/input-old"); // input first regardless of activity
+        assert_eq!(rooms[1].name, "/idle-recent"); // most recent activity
+        assert_eq!(rooms[2].name, "/idle-old"); // older activity
+        assert_eq!(rooms[3].name, "/egg"); // no activity last
     }
 }

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -92,12 +92,26 @@ tmux start-server 2>/dev/null || true
 create_session() {
     local name="$1" cwd="$2"
     mkdir -p "$cwd"
-    tmux new-session -d -s "$name" -c "$cwd" "$(which claude) $CLAUDE_FLAGS"
+    # Pre-authorize `sleep` only, so the working_state test's deterministic
+    # `sleep` runs instead of parking at a permission prompt under manual mode.
+    # Every other tool (e.g. Write in input_state) still prompts as normal.
+    tmux new-session -d -s "$name" -c "$cwd" "$(which claude) $CLAUDE_FLAGS --allowedTools 'Bash(sleep *)'"
 }
 
+# Submit a prompt to a Claude Code pane.
+#
+# The prompt text and the Enter keystroke are sent as two separate send-keys
+# calls with a short settle in between. Newer Claude TUIs treat a fast burst of
+# input as a bracketed paste and swallow an Enter that arrives in the same
+# instant, leaving the prompt sitting unsubmitted in the input box (which then
+# reads as New/Idle forever). Sending Enter on its own after the paste settles
+# submits reliably. $name may be a session name or a full pane target (e.g.
+# "sess:0.0").
 send_to_session() {
     local name="$1" text="$2"
-    tmux send-keys -t "$name" "$text" Enter
+    tmux send-keys -t "$name" "$text"
+    sleep 0.7
+    tmux send-keys -t "$name" Enter
 }
 
 get_state() {
@@ -170,7 +184,12 @@ if should_run "working_state"; then
 
     # Wait for the TUI to be fully ready for input
     sleep 3
-    send_to_session "$S_NEW" "wait 10 seconds and then run ls"
+    # A `sleep` gives a deterministic ~10s Working window, independent of model
+    # generation speed (a pure-generation prompt can finish between poll cycles
+    # and be missed). `sleep` is pre-authorized in create_session so it runs
+    # instead of parking at a permission prompt, and the session then settles to
+    # Idle for the idle_state test (which reuses this session).
+    send_to_session "$S_NEW" "Run this exact bash command and nothing else: sleep 10"
 
     if wait_for_state "$S_NEW" "Working" 15; then
         report pass "Working state detected for $S_NEW"
@@ -422,7 +441,7 @@ if should_run "multi_pane_status"; then
 
     # Send a long prompt to the Claude pane specifically (pane 0, not the active pane)
     sleep 3
-    tmux send-keys -t "$S_MULTI:0.0" "read all .txt files in this directory and write a combined summary to summary.txt" Enter
+    send_to_session "$S_MULTI:0.0" "read all .txt files in this directory and write a combined summary to summary.txt"
 
     if wait_for_state "$S_MULTI" "Working" 20; then
         report pass "Multi-pane status: Working detected despite bash pane being active"
@@ -470,7 +489,7 @@ if should_run "dual_pane_discovery"; then
     sleep 3
 
     # Do some work to get a session with tokens
-    tmux send-keys -t "$S_DUAL:0.0" "say exactly: dual pane test" Enter
+    send_to_session "$S_DUAL:0.0" "say exactly: dual pane test"
     wait_for_state "$S_DUAL" "Idle" 30 >/dev/null 2>&1 || true
 
     # Exit Claude — bash shell remains in pane 0
@@ -492,7 +511,7 @@ if should_run "dual_pane_discovery"; then
         tmux send-keys -t "$S_DUAL:0.0" "$CLAUDE_PATH $CLAUDE_FLAGS" Enter
         wait_for_state "$S_DUAL" "New" 15 >/dev/null 2>&1 || true
         sleep 3
-        tmux send-keys -t "$S_DUAL:0.0" "say exactly: fresh session" Enter
+        send_to_session "$S_DUAL:0.0" "say exactly: fresh session"
         wait_for_state "$S_DUAL" "Idle" 30 >/dev/null 2>&1 || true
 
         # Split window and start resumed Claude in pane 1 (same tmux session, same CWD)


### PR DESCRIPTION
Two independent chores, kept as separate commits for clean review.

## 1. Reformat codebase with cargo fmt

Pure formatting, no behavioral change — brings the tree in line with the current stable rustfmt so `cargo fmt --check` passes cleanly. Isolated into its own commit so it doesn't muddy future diffs.

## 2. Stabilize e2e status-detection tests

The status-detection tests (`working_state`, `input_state`, `multi_pane_status`, `idle_state`) were failing against Claude Code v2.1.212. Root causes, empirically diagnosed by driving a live TUI and snapshotting panes:

- **Unsubmitted prompts.** The newer TUI treats a fast input burst as a bracketed paste and swallows an `Enter` sent in the *same* `send-keys` call — the prompt sits unsubmitted in the input box, so the session reads as `New`/`Idle` forever. Fixed by submitting in two steps (text → settle → `Enter`) in `send_to_session`, and routing the multi/dual pane sends through it too.
- **Permission-prompt trap.** `working_state` used `"wait 10 seconds and then run ls"`; under the newer manual-mode default that parks at a Bash permission prompt (`Input`) and never reaches `Idle` (which `idle_state` depends on). Replaced with a deterministic `sleep 10` — same guaranteed ~10s Working window, independent of model speed — and pre-authorized **only** `sleep` via `--allowedTools 'Bash(sleep *)'` in `create_session`. Every other permission (e.g. `input_state`'s Write prompt) is unchanged, so `input_state` still exercises a real permission prompt.

`pane_status` itself was confirmed correct against the new TUI (the `✻ …ing…` spinner and the `❯ 1.` / `Esc to cancel` permission prompt are both still detected) — no source change needed.

Full suite passes **16/16 across repeated runs**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)